### PR TITLE
fix: 닉네임 수정시 기존의글,댓글 닉네임도 수정되도록 구현

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "poket-traders"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,19 @@
+{
+  "functions": [
+    {
+      "source": "functions",
+      "codebase": "default",
+      "ignore": [
+        "node_modules",
+        ".git",
+        "firebase-debug.log",
+        "firebase-debug.*.log",
+        "*.local"
+      ],
+      "predeploy": [
+        "npm --prefix \"$RESOURCE_DIR\" run lint",
+        "npm --prefix \"$RESOURCE_DIR\" run build"
+      ]
+    }
+  ]
+}

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,4 +1,11 @@
-import { doc, updateDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  where,
+  writeBatch,
+} from "firebase/firestore";
 import { UserInfoUpdateFormRequest } from "./types";
 import { auth, db } from "@/lib/firebase";
 
@@ -7,11 +14,69 @@ export async function updateUserInfo(data: UserInfoUpdateFormRequest) {
     const user = auth.currentUser;
     if (!user) throw new Error("로그인이 필요합니다.");
 
+    const batch = writeBatch(db);
+
+    // 사용자 정보 업데이트
     const userRef = doc(db, "users", user.uid);
-    await updateDoc(userRef, {
+    batch.update(userRef, {
       nickname: data.nickname,
       friendId: data.friendId,
     });
+
+    // 사용자가 작성한 모든 게시글의 닉네임 업데이트
+    const cardTradesQuery = query(
+      collection(db, "card-trade"),
+      where("uid", "==", user.uid)
+    );
+    const cardTradesSnapshot = await getDocs(cardTradesQuery);
+
+    cardTradesSnapshot.forEach((docSnapshot) => {
+      const tradeRef = doc(db, "card-trade", docSnapshot.id);
+      batch.update(tradeRef, {
+        authorName: data.nickname,
+        friendId: data.friendId,
+      });
+    });
+
+    // 3. 사용자가 작성한 모든 댓글의 authorName 업데이트
+    const userCommentsQuery = query(
+      collection(db, "users", user.uid, "comments")
+    );
+    const userCommentsSnapshot = await getDocs(userCommentsQuery);
+
+    for (const commentDoc of userCommentsSnapshot.docs) {
+      const commentData = commentDoc.data();
+      if (commentData.tradeId && commentData.commentId) {
+        // 각 게시글의 댓글 컬렉션에서도 업데이트
+        const commentRef = doc(
+          db,
+          "card-trade",
+          commentData.tradeId,
+          "comments",
+          commentData.commentId
+        );
+        batch.update(commentRef, {
+          authorName: data.nickname,
+          friendId: data.friendId,
+        });
+      }
+
+      // 사용자별 댓글 컬렉션도 업데이트
+      const userCommentRef = doc(
+        db,
+        "users",
+        user.uid,
+        "comments",
+        commentDoc.id
+      );
+      batch.update(userCommentRef, {
+        authorName: data.nickname,
+        friendId: data.friendId,
+      });
+    }
+
+    // 모든 업데이트를 한 번에 실행
+    await batch.commit();
     return {
       success: true,
       message: "사용자 정보가 성공적으로 업데이트되었습니다.",

--- a/src/apis/user/queries.ts
+++ b/src/apis/user/queries.ts
@@ -6,8 +6,12 @@ export function useUpdateUserInfo() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: UserInfoUpdateFormRequest) => updateUserInfo(data),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       queryClient.invalidateQueries({ queryKey: ["user"] });
+      queryClient.invalidateQueries({ queryKey: ["cardTrades"] });
+      queryClient.invalidateQueries({ queryKey: ["comments"] });
+      window.location.reload();
     },
   });
 }


### PR DESCRIPTION
## 🎯 뭘 했나요?

- batch를 활용하여 유저의 정보가 수정시 각 데이터들을 동시다발적으로 수정이 되도록 구현.

## 📸 스크린샷 (있으면)

## 🔗 관련 이슈
비용이 높은 동작으로 예상.

#
