### PR TITLE
fix(#45): 마이페이지 새로고침시 유저데이터를 유지하도록 수정

### DIFF
--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -75,7 +75,6 @@ export async function updateUserInfo(data: UserInfoUpdateFormRequest) {
       });
     }
 
-    // 모든 업데이트를 한 번에 실행
     await batch.commit();
     return {
       success: true,

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,7 +9,7 @@ import { useEffect, useState } from "react";
 export function useAuth() {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [loading, setLoading] = useState(true);
-  const { data: user } = useGetUser();
+  const { data: user, isLoading } = useGetUser();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
@@ -26,7 +26,7 @@ export function useAuth() {
 
   return {
     user: isAuthenticated ? user : null,
-    loading,
+    loading: loading || isLoading,
     isUserHasFriendId: isUserHasFriendId(user),
   };
 }


### PR DESCRIPTION
## 🎯 뭘 했나요?

- useAuth훅에서 user데이터를 불러올때도 loading을 사용하여 비동기처리를 기다릴수 있도록 설정.

## 📸 스크린샷 (있으면)

## 🔗 관련 이슈

#45
